### PR TITLE
Add Jetbot conversion notebook

### DIFF
--- a/jetbot/convert_jetbot_to_droid.ipynb
+++ b/jetbot/convert_jetbot_to_droid.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Convert Jetbot CSV to DROID Dataset\n",
+    "This notebook converts a Jetbot CSV recording into the DROID dataset format expected by the VJEPA training scripts.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import csv\n",
+    "import json\n",
+    "from collections import defaultdict\n",
+    "import cv2\n",
+    "import numpy as np\n",
+    "import h5py\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Utility functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def read_csv(csv_path):\n",
+    "    sessions = defaultdict(list)\n",
+    "    with open(csv_path, newline=\"\") as f:\n",
+    "        reader = csv.DictReader(f)\n",
+    "        for row in reader:\n",
+    "            sessions[row['session_id'].strip()].append(row)\n",
+    "    for rows in sessions.values():\n",
+    "        rows.sort(key=lambda r: float(r['timestamp']))\n",
+    "    return sessions\n",
+    "\n",
+    "def ensure_dir(p):\n",
+    "    if not os.path.exists(p):\n",
+    "        os.makedirs(p)\n",
+    "\n",
+    "def create_video(session_rows, base_dir, video_path, fps):\n",
+    "    first_img = cv2.imread(os.path.join(base_dir, session_rows[0]['image_path']))\n",
+    "    if first_img is None:\n",
+    "        raise FileNotFoundError(session_rows[0]['image_path'])\n",
+    "    h, w = first_img.shape[:2]\n",
+    "    writer = cv2.VideoWriter(video_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (w, h))\n",
+    "    for row in session_rows:\n",
+    "        img = cv2.imread(os.path.join(base_dir, row['image_path']))\n",
+    "        if img is None:\n",
+    "            raise FileNotFoundError(row['image_path'])\n",
+    "        if img.shape[:2] != (h, w):\n",
+    "            img = cv2.resize(img, (w, h))\n",
+    "        writer.write(img)\n",
+    "    writer.release()\n",
+    "\n",
+    "def build_trajectory(session_rows):\n",
+    "    n = len(session_rows)\n",
+    "    cartesian = np.zeros((n, 6), dtype=np.float32)\n",
+    "    gripper = np.zeros((n,), dtype=np.float32)\n",
+    "    pos = 0.0\n",
+    "    for i, row in enumerate(session_rows):\n",
+    "        try:\n",
+    "            action = float(row['action'])\n",
+    "        except ValueError:\n",
+    "            action = 0.0\n",
+    "        pos += action\n",
+    "        cartesian[i, 0] = pos\n",
+    "    extrinsics = np.zeros((n, 6), dtype=np.float32)\n",
+    "    return cartesian, gripper, extrinsics\n",
+    "\n",
+    "def write_h5(path, cartesian, gripper, extrinsics):\n",
+    "    with h5py.File(path, 'w') as f:\n",
+    "        obs = f.create_group('observation')\n",
+    "        robot = obs.create_group('robot_state')\n",
+    "        robot.create_dataset('cartesian_position', data=cartesian)\n",
+    "        robot.create_dataset('gripper_position', data=gripper)\n",
+    "        ce = obs.create_group('camera_extrinsics')\n",
+    "        ce.create_dataset('left_left', data=extrinsics)\n",
+    "\n",
+    "def process_sessions(sessions, base_dir, out_dir, fps):\n",
+    "    list_file = os.path.join(out_dir, 'droid_paths.csv')\n",
+    "    lines = []\n",
+    "    for sid, rows in sessions.items():\n",
+    "        sdir = os.path.join(out_dir, sid)\n",
+    "        mp4_dir = os.path.join(sdir, 'recordings', 'MP4')\n",
+    "        ensure_dir(mp4_dir)\n",
+    "        video_path = os.path.join(mp4_dir, 'left.mp4')\n",
+    "        create_video(rows, base_dir, video_path, fps)\n",
+    "        cartesian, gripper, extrinsics = build_trajectory(rows)\n",
+    "        write_h5(os.path.join(sdir, 'trajectory.h5'), cartesian, gripper, extrinsics)\n",
+    "        meta = {'left_mp4_path': os.path.join('recordings', 'MP4', 'left.mp4')}\n",
+    "        with open(os.path.join(sdir, 'metadata.json'), 'w') as f:\n",
+    "            json.dump(meta, f)\n",
+    "        lines.append(sdir)\n",
+    "    with open(list_file, 'w') as f:\n",
+    "        for l in lines:\n",
+    "            f.write(l + '\n')\n",
+    "    print(f'Wrote dataset list to {list_file}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example usage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# csv_path = 'jetbot/sample.csv'\n",
+    "# data_dir = 'jetbot'  # directory containing the images referenced in the CSV\n",
+    "# output_dir = 'jetbot_droid'\n",
+    "# fps = 4\n",
+    "#\n",
+    "# sessions = read_csv(csv_path)\n",
+    "# ensure_dir(output_dir)\n",
+    "# process_sessions(sessions, data_dir, output_dir, fps)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/convert_jetbot_to_droid.py
+++ b/scripts/convert_jetbot_to_droid.py
@@ -1,0 +1,113 @@
+import argparse
+import csv
+import json
+import os
+from collections import defaultdict
+
+import cv2
+import h5py
+import numpy as np
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Convert Jetbot CSV to DROID dataset format")
+    parser.add_argument("csv_path", type=str, help="Path to Jetbot CSV")
+    parser.add_argument("data_dir", type=str, help="Directory containing Jetbot images")
+    parser.add_argument("output_dir", type=str, help="Where to write DROID formatted dataset")
+    parser.add_argument("--fps", type=int, default=4, help="Frames per second for generated videos")
+    return parser.parse_args()
+
+
+def read_csv(csv_path):
+    sessions = defaultdict(list)
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            sessions[row["session_id"].strip()].append(row)
+    # sort by timestamp within session
+    for s in sessions.values():
+        s.sort(key=lambda r: float(r["timestamp"]))
+    return sessions
+
+
+def ensure_dir(p):
+    if not os.path.exists(p):
+        os.makedirs(p)
+
+
+def create_video(session_rows, base_dir, video_path, fps):
+    # assume at least one row
+    first_img = cv2.imread(os.path.join(base_dir, session_rows[0]["image_path"]))
+    if first_img is None:
+        raise FileNotFoundError(session_rows[0]["image_path"])
+    height, width = first_img.shape[:2]
+    writer = cv2.VideoWriter(
+        video_path, cv2.VideoWriter_fourcc(*"mp4v"), fps, (width, height)
+    )
+    for row in session_rows:
+        img = cv2.imread(os.path.join(base_dir, row["image_path"]))
+        if img is None:
+            raise FileNotFoundError(row["image_path"])
+        if img.shape[:2] != (height, width):
+            img = cv2.resize(img, (width, height))
+        writer.write(img)
+    writer.release()
+
+
+def build_trajectory(session_rows):
+    n = len(session_rows)
+    cartesian = np.zeros((n, 6), dtype=np.float32)
+    gripper = np.zeros((n,), dtype=np.float32)
+    # integrate 1D action into the first axis of cartesian position
+    pos = 0.0
+    for i, row in enumerate(session_rows):
+        try:
+            action = float(row["action"])
+        except ValueError:
+            action = 0.0
+        pos += action
+        cartesian[i, 0] = pos
+    extrinsics = np.zeros((n, 6), dtype=np.float32)
+    return cartesian, gripper, extrinsics
+
+
+def write_h5(path, cartesian, gripper, extrinsics):
+    with h5py.File(path, "w") as f:
+        obs = f.create_group("observation")
+        robot = obs.create_group("robot_state")
+        robot.create_dataset("cartesian_position", data=cartesian)
+        robot.create_dataset("gripper_position", data=gripper)
+        ce = obs.create_group("camera_extrinsics")
+        ce.create_dataset("left_left", data=extrinsics)
+
+
+def process_sessions(sessions, base_dir, out_dir, fps):
+    list_file = os.path.join(out_dir, "droid_paths.csv")
+    lines = []
+    for sid, rows in sessions.items():
+        sdir = os.path.join(out_dir, sid)
+        mp4_dir = os.path.join(sdir, "recordings", "MP4")
+        ensure_dir(mp4_dir)
+        video_path = os.path.join(mp4_dir, "left.mp4")
+        create_video(rows, base_dir, video_path, fps)
+        cartesian, gripper, extrinsics = build_trajectory(rows)
+        write_h5(os.path.join(sdir, "trajectory.h5"), cartesian, gripper, extrinsics)
+        meta = {"left_mp4_path": os.path.join("recordings", "MP4", "left.mp4")}
+        with open(os.path.join(sdir, "metadata.json"), "w") as f:
+            json.dump(meta, f)
+        lines.append(sdir)
+    with open(list_file, "w") as f:
+        for l in lines:
+            f.write(l + "\n")
+    print(f"Wrote dataset list to {list_file}")
+
+
+def main():
+    args = parse_args()
+    sessions = read_csv(args.csv_path)
+    ensure_dir(args.output_dir)
+    process_sessions(sessions, args.data_dir, args.output_dir, args.fps)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Jupyter notebook that converts Jetbot CSV logs into a DROID style dataset

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy' and 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68503d40e4dc8331b25249dab07a1876